### PR TITLE
前処理テスト追加 + テスト反映修正

### DIFF
--- a/home/frk_ftp/scripts/remove_work_images.sh 
+++ b/home/frk_ftp/scripts/remove_work_images.sh 
@@ -2,4 +2,9 @@
 
 set -ex
 
-rm -rf /home/frk_ftp/works/images/
+rm -rf /home/frk_ftp/agent/mitsubishiufj/madori/*
+rm -rf /home/frk_ftp/agent/mitsubishiufj/photo/*
+rm -rf /home/frk_ftp/agent/mitsubishiufj/photo2/*
+rm -rf /home/frk_ftp/agent/mitsubishiufj/photo3/*
+rm -rf /home/frk_ftp/agent/mitsubishiufj/photo4/*
+rm -rf /home/frk_ftp/agent/mitsubishiufj/photo5/*

--- a/home/frk_ftp/scripts/test/test.sh
+++ b/home/frk_ftp/scripts/test/test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+if [ "$TEST_MODE" = "true" ]; then
+    echo "test mode is true"
+else
+    echo "test mode is false"
+    exit 1
+fi
+
+DATETIME=$(date '+%Y%m%d%H%M%S')
+DATE=$(date '+%Y%m%d')
+
+./remove_work_images.sh
+{
+    ls "/home/frk_ftp/agents/mitsubishiufj/"
+    echo "--- 画像削除 終了 --- ${DATETIME}"
+} >> "/home/frk_ftp/scripts/testlog_${DATETIME}.log"
+
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/madori"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/photo"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/photo2"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/photo3"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/photo4"
+mkdir -p "/home/frk_ftp/agents/mitsubishiufj/photo5"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/madori/12345678.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/madori/12345679.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/madori/12345680.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/madori/12345681.jpg"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/photo/12345678.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo/12345679.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo/12345680.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo/12345681.jpg"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/photo2/12345678.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo2/12345679.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo2/12345680.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo2/12345681.jpg"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/photo3/12345678.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo3/12345679.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo3/12345680.jpg"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/photo4/12345678.jpg"
+touch "/home/frk_ftp/agents/mitsubishiufj/photo4/12345679.jpg"
+
+touch "/home/frk_ftp/agents/mitsubishiufj/photo5/12345678.jpg"
+
+{
+    echo "--- データ作成 終了 --- ${DATETIME}"
+} >> "/home/frk_ftp/scripts/testlog_${DATETIME}.log"
+
+./upload_csv_to_s3.sh
+{
+    aws s3 ls "s3://recat-staging/estates_import/frk/${DATE}/"
+    echo "--- CSVアップロード 終了 --- ${DATETIME}"
+} >> "/home/frk_ftp/scripts/testlog_${DATETIME}.log"
+
+./upload_picture_avail_to_s3.sh
+{
+    cat "/home/frk_ftp/agents/mitsubishiufj/frk_bukken_check.csv"
+    aws s3 ls "s3://recat-staging/estate_import/frk/${DATE}/"
+    echo "--- 画像存在チェックアップロード 終了 --- ${DATETIME}"
+} >> "/home/frk_ftp/scripts/testlog_${DATETIME}.log"
+
+echo "test ok"
+rm -rf "/home/frk_ftp/agents/mitsubishiufj/"
+echo "clean up ok"
+
+echo "--- clean up 終了 --- ${DATETIME}" >> "/home/frk_ftp/scripts/testlog_${DATETIME}.log"
+exit 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/home/frk_ftp/scripts/upload_csv_to_s3.sh
+++ b/home/frk_ftp/scripts/upload_csv_to_s3.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-date=$(date "+%Y-%m-%d-%H")
-aws s3 cp /home/frk_ftp/works/agents/ s3://recat/estates_import/frk/$date/ --recursive --exclude '*' --include '*.csv'
+
+aws s3 cp /home/frk_ftp/agents "s3://recat-staging/estates_import/frk/$(date +%Y%m%d)/" --recursive --exclude '*' --include '*.csv'

--- a/home/frk_ftp/scripts/upload_picture_avail_to_s3.sh
+++ b/home/frk_ftp/scripts/upload_picture_avail_to_s3.sh
@@ -1,40 +1,41 @@
 #!/bin/bash
 
 DATE=$(date +%Y-%m-%d\ %H:%M:%S)
-BASE_DIR="/home/frk_ftp/works/agents"
+BASE_DIR="/home/frk_ftp/agents"
 OUTPUT_FILE_NAME="frk_bukken_check.csv"
-OUTPUT_FILE_PATH="/home/frk_ftp/works/agents/mitsubishiufj/$OUTPUT_FILE_NAME"
-LOG_FILE_SCRIPT="/home/frk_ftp/works/agents/mitsubishiufj/frk_bukken_check.log"
+OUTPUT_FILE_PATH="$BASE_DIR/mitsubishiufj/$OUTPUT_FILE_NAME"
+LOG_FILE_SCRIPT="/home/frk_ftp/log/mitsubishiufj/frk_bukken_check.log"
 LOG_FILE_GENERAL="/home/frk_ftp/log/output.log"
 
 # 出力ファイルのヘッダー作成
-echo "frk_bukken_id,madori,photo,photo2,photo3,photo4,photo5" > "$OUTPUT_FILE"
+touch "$OUTPUT_FILE_PATH"
+echo "frk_bukken_id,madori,photo,photo2,photo3,photo4,photo5" > "$OUTPUT_FILE_PATH"
+
+# 物件IDのリストを生成（例：madoriディレクトリ内のファイルから）
+find "$BASE_DIR/mitsubishiufj/madori" -type f -name "*.jpg" -exec basename {} .jpg \; | sort -u > /tmp/bukken_list.txt
 
 # ファイルリストの各ファイル名に対して処理
-while IFS= read -r filename; do
-    frk_bukken_id="${filename%.*}"
-
-    madori_exists=$([ -f "$BASE_DIR/madori/$filename" ] && echo "true" || echo "false")
-    photo_exists=$([ -f "$BASE_DIR/photo/$filename" ] && echo "true" || echo "false")
-    photo2_exists=$([ -f "$BASE_DIR/photo2/$filename" ] && echo "true" || echo "false")
-    photo3_exists=$([ -f "$BASE_DIR/photo3/$filename" ] && echo "true" || echo "false")
-    photo4_exists=$([ -f "$BASE_DIR/photo4/$filename" ] && echo "true" || echo "false")
-    photo5_exists=$([ -f "$BASE_DIR/photo5/$filename" ] && echo "true" || echo "false")
+while IFS= read -r frk_bukken_id; do
+    madori_exists=$([ -f "$BASE_DIR/mitsubishiufj/madori/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
+    photo_exists=$([ -f "$BASE_DIR/mitsubishiufj/photo/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
+    photo2_exists=$([ -f "$BASE_DIR/mitsubishiufj/photo2/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
+    photo3_exists=$([ -f "$BASE_DIR/mitsubishiufj/photo3/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
+    photo4_exists=$([ -f "$BASE_DIR/mitsubishiufj/photo4/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
+    photo5_exists=$([ -f "$BASE_DIR/mitsubishiufj/photo5/$frk_bukken_id.jpg" ] && echo "true" || echo "false")
     
     # 結果をCSVファイルに追記
-    echo "$frk_bukken_id,$madori_exists,$photo_exists,$photo2_exists,$photo3_exists,$photo4_exists,$photo5_exists" >> "$OUTPUT_FILE_NAME"
-done < "$OUTPUT_FILE_PATH"
+    echo "$frk_bukken_id,$madori_exists,$photo_exists,$photo2_exists,$photo3_exists,$photo4_exists,$photo5_exists" >> "$OUTPUT_FILE_PATH"
+done < /tmp/bukken_list.txt
 
-if ! tail -n 1 "$OUTPUT_FILE_PATH" | grep -q "frk_bukken_id"; then
-    echo "--- file check failed --- $DATE" > "$LOG_FILE_SCRIPT"
-    echo "--- file check failed --- $DATE" >> "$LOG_FILE_GENERAL"
-    exit 1
-fi
+# 一時ファイルの削除
+rm /tmp/bukken_list.txt
 
 echo "--- file check completed --- $DATE" > "$LOG_FILE_SCRIPT"
 echo "--- file check completed --- $DATE" >> "$LOG_FILE_GENERAL"
 
-if aws s3 cp "$OUTPUT_FILE" "s3:///recat-staging/estate_import/frk/$(date +%Y%m%d)/${OUTPUT_FILE}"; then
+cat $OUTPUT_FILE_PATH
+
+if aws s3 cp "$OUTPUT_FILE_PATH" "s3://recat-staging/estates_import/frk/$(date +%Y%m%d)/mitsubishiufj/${OUTPUT_FILE_NAME}"; then
     echo "--- file upload completed --- $DATE" > "$LOG_FILE_SCRIPT"
     echo "--- file upload completed --- $DATE" >> "$LOG_FILE_GENERAL"
     exit 0
@@ -43,3 +44,4 @@ else
     echo "--- file upload failed --- $DATE" >> "$LOG_FILE_GENERAL"
     exit 1
 fi
+


### PR DESCRIPTION
前処理までの結合テストを追加した上で動作を修正します

```
[root@ip-10-0-21-214 scripts]# TEST_MODE=true ./test.sh
test mode is true
+ rm -rf /home/frk_ftp/works/images/
upload: ../agents/mitsubishiufj/frk_chukai.csv to s3://recat-staging/estates_import/frk/20250219/mitsubishiufj/frk_chukai.csv
frk_bukken_id,madori,photo,photo2,photo3,photo4,photo5
12345678,true,true,true,true,true,true
12345679,true,true,true,true,true,false
12345680,true,true,true,true,false,false
12345681,true,true,true,false,false,false
upload: ../agents/mitsubishiufj/frk_bukken_check.csv to s3://recat-staging/estates_import/frk/20250219/mitsubishiufj/frk_bukken_check.csv
test ok
clean up ok
```